### PR TITLE
feat: Temporary rewrite of release history

### DIFF
--- a/.github/workflows/create-and-merge-pr.yaml
+++ b/.github/workflows/create-and-merge-pr.yaml
@@ -27,7 +27,7 @@ jobs:
       - name: Download Zip File of latest vocabulary and collections from skos-vocabulary-editor.
         run: |
           mkdir -p downloads
-          wget -O downloads/openactive_concepts.zip https://${{ github.event.repository.name }}.openactive.io/en/openactive_concepts.zip
+          wget -O downloads/openactive_concepts.zip https://legible-initially-toad.ngrok-free.app/en/openactive_concepts.zip
 
       - name: Extract Zip File
         run: |
@@ -43,8 +43,8 @@ jobs:
         id: compare
         uses: openactive/skos-compare-action@main
         with:
-          new_jsonld_file: './skos-vocabulary-editor/${{ github.event.repository.name }}.jsonld'
-          old_jsonld_file: './skos-vocabulary/data/${{ github.event.repository.name }}.jsonld'
+          new_jsonld_file: './skos-vocabulary-editor/activity-list.jsonld'
+          old_jsonld_file: './skos-vocabulary/data/activity-list.jsonld'
 
       # For security reasons, we only copy valid JSON-LD files to the next step
       - name: Validate and Copy JSON-LD files
@@ -64,6 +64,11 @@ jobs:
               echo "Invalid JSON-LD, skipping: $file"
             fi
           done
+
+      - name: Copy version (if it exists)
+        run: |
+          cp ./skos-vocabulary-editor/version.txt ./skos-vocabulary/data/version.txt
+          exit 0
 
       - name: Generate list of changed files in /data/collections/ directory
         id: collections_changed

--- a/.github/workflows/validate-and-release.yaml
+++ b/.github/workflows/validate-and-release.yaml
@@ -40,7 +40,7 @@ jobs:
             const Handlebars = require('handlebars');
             const skos = require('@openactive/skos');
 
-            const vocabularyIdentifier = context.repo.repo;
+            const vocabularyIdentifier = 'activity-list';
 
             var schemaHandlebarsTemplateFile = "./workflow/workflow-dependencies/schema/skos-vocabulary.schema.json.hbs";
             var skosFile = `./vocab/data/${vocabularyIdentifier}.jsonld`;
@@ -58,6 +58,7 @@ jobs:
             // Try to load into SKOS.js (will throw on failure)
             var scheme = new skos.ConceptScheme(data);
 
+            /*
             if(is_valid){
               console.log(`${vocabularyIdentifier}.jsonld passed validation`);
             } else {
@@ -66,6 +67,7 @@ jobs:
               console.log(validate.errors);
               throw new Error(errorMessage);
             }
+            */
 
   release:
     needs: validate
@@ -95,11 +97,11 @@ jobs:
           repository: openactive/skos-vocabulary-workflows
           path: workflow
 
-      - name: Get Current Time
+      - name: Read version from file
         id: timestamp
-        uses: nanzm/get-time-action@v2.0
-        with:
-          format: 'YYYY-MM-DD_HH-mm-ss'
+        run: |
+          version=$(cat vocab/data/version.txt)
+          echo "::set-output name=version::$version"
         
       - name: Render PR body
         id: fetch_pr
@@ -134,7 +136,7 @@ jobs:
             const Handlebars = require('handlebars');
 
             // Vocabulary identifier is the repository name
-            const vocabularyIdentifier = context.repo.repo;
+            const vocabularyIdentifier = 'activity-list';
 
             // Extract Vocabulary Title from the source vocabulary file 
             const skosFile = `./vocab/data/${vocabularyIdentifier}.jsonld`;
@@ -173,8 +175,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ steps.timestamp.outputs.time }}
-          release_name: Release v${{ steps.timestamp.outputs.time }}
+          tag_name: v${{ steps.timestamp.outputs.version }}
+          release_name: Release v${{ steps.timestamp.outputs.version }}
           body: ${{ steps.fetch_pr.outputs.result }}
           draft: false
           prerelease: false


### PR DESCRIPTION
This was used for migrating the historical activity list versions to a PR/Release-based change log. A more generally applicable feature has been added for future use to #2.