### PR TITLE
feat: Accept release timestamp as input

### DIFF
--- a/.github/workflows/create-and-merge-pr.yaml
+++ b/.github/workflows/create-and-merge-pr.yaml
@@ -7,6 +7,10 @@ on:
         description: 'Author of this release'     
         required: true
         type: string
+      timestamp:
+        description: 'Date of this release'     
+        required: false
+        type: string
     secrets:
       PUBLIC_REPO_ACCESS_TOKEN:
         description: 'The GitHub token to use for creating and auto-merging the PR'
@@ -64,6 +68,18 @@ jobs:
               echo "Invalid JSON-LD, skipping: $file"
             fi
           done
+
+      - name: Write timestamp to file (if provided)
+        if: ${{ inputs.timestamp != '' }}
+        run: |
+          echo "${{ inputs.timestamp }}" > ./skos-vocabulary/data/version.txt
+
+      - name: Delete version.txt if timestamp is not provided
+        if: ${{ inputs.timestamp == '' }}
+        run: |
+          if [ -f ./skos-vocabulary/data/version.txt ]; then
+            rm ./skos-vocabulary/data/version.txt
+          fi
 
       - name: Generate list of changed files in /data/collections/ directory
         id: collections_changed

--- a/.github/workflows/validate-and-release.yaml
+++ b/.github/workflows/validate-and-release.yaml
@@ -95,12 +95,22 @@ jobs:
           repository: openactive/skos-vocabulary-workflows
           path: workflow
 
-      - name: Get Current Time
+      - name: Get current time
         id: timestamp
         uses: nanzm/get-time-action@v2.0
         with:
           format: 'YYYY-MM-DD_HH-mm-ss'
-        
+
+      - name: Read version from file (if it exists)
+        id: version
+        run: |
+          if [ -f vocab/data/version.txt ]; then
+            version=$(cat vocab/data/version.txt)
+          else
+            version=""
+          fi
+          echo "::set-output name=version::$version"
+
       - name: Render PR body
         id: fetch_pr
         uses: actions/github-script@v7
@@ -173,8 +183,8 @@ jobs:
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:
-          tag_name: v${{ steps.timestamp.outputs.time }}
-          release_name: Release v${{ steps.timestamp.outputs.time }}
+          tag_name: v${{ steps.version.outputs.version || steps.timestamp.outputs.time }}
+          release_name: Release v${{ steps.version.outputs.version || steps.timestamp.outputs.time }}
           body: ${{ steps.fetch_pr.outputs.result }}
           draft: false
           prerelease: false


### PR DESCRIPTION
This allows for historic releases to be recorded accurately when they are migrated to iQvoc